### PR TITLE
Handle shift+click recipe transfers

### DIFF
--- a/src/main/java/dev/nolij/toomanyrecipeviewers/mixin/PacketRecipeTransferAccessor.java
+++ b/src/main/java/dev/nolij/toomanyrecipeviewers/mixin/PacketRecipeTransferAccessor.java
@@ -1,0 +1,11 @@
+package dev.nolij.toomanyrecipeviewers.mixin;
+
+import mezz.jei.common.network.packets.PacketRecipeTransfer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(PacketRecipeTransfer.class)
+public interface PacketRecipeTransferAccessor {
+    @Accessor("maxTransfer")
+    boolean tmrv$isMaxTransfer();
+}

--- a/src/main/resources/toomanyrecipeviewers.mixins.json
+++ b/src/main/resources/toomanyrecipeviewers.mixins.json
@@ -13,6 +13,7 @@
 		"JemiUtilMixin",
 		"NormalizedTypedItemMixin",
 		"NormalizedTypedItemStackMixin",
+		"PacketRecipeTransferAccessor",
 		"SmithingRecipeCategoryAccessor",
 		"TypedIngredientMixin",
 		"TypedItemStackMixin",


### PR DESCRIPTION
We can use EMI's existing logic for calculating the stack counts by supplying fake proxy objects with the required information. 