### PR TITLE
fix: Create fan's smoking/blasting recipe don't show in EMI

### DIFF
--- a/src/main/java/dev/nolij/toomanyrecipeviewers/impl/jei/api/recipe/RecipeManager.java
+++ b/src/main/java/dev/nolij/toomanyrecipeviewers/impl/jei/api/recipe/RecipeManager.java
@@ -456,18 +456,19 @@ public class RecipeManager implements IRecipeManager, TooManyRecipeViewers.ILock
 	private final Set<ResourceLocation> replacedRecipeIDs = Collections.synchronizedSet(new HashSet<>());
 	private final Set<EmiRecipe> replacementRecipes = Collections.synchronizedSet(new HashSet<>());
 	private <T> void addRecipe(Category<T> category, T jeiRecipe) {
+		final var jeiCategory = category.getJEICategory();
+		final var jeiRecipeType = Objects.requireNonNull(jeiCategory).getRecipeType();
 		//? if >=21.1 {
-		if (category.isVanillaType() &&
+		if (vanillaJEITypeEMICategoryMap.containsKey(jeiRecipeType) &&
 			jeiRecipe instanceof RecipeHolder<?> holder && 
 			runtime.ignoredRecipes.contains(holder.value()))
 			return;
 		//?} else {
-		/*if (category.isVanillaType() &&
+		/*if (vanillaJEITypeEMICategoryMap.containsKey(jeiRecipeType) &&
 			runtime.ignoredRecipes.contains(jeiRecipe))
 			return;
 		*///?}
-		final var jeiCategory = category.getJEICategory();
-		if (!Objects.requireNonNull(jeiCategory).isHandled(jeiRecipe)) {
+		if (!jeiCategory.isHandled(jeiRecipe)) {
 			if (LOGGER.isDebugEnabled()) {
 				String recipeInfo = RecipeDebugUtil.getDebugInfoFromRecipe(jeiRecipe, jeiCategory, ingredientManager);
 				LOGGER.debug("Recipe not added because the recipe category cannot handle it: {}", recipeInfo);
@@ -479,7 +480,7 @@ public class RecipeManager implements IRecipeManager, TooManyRecipeViewers.ILock
 			final var recipe = category.recipe(jeiRecipe);
 			final var emiRecipe = Objects.requireNonNull(recipe.getEMIRecipe());
 			registry.addRecipe(emiRecipe);
-			if (category.isVanillaType() && recipe.getOriginalID() != null) {
+			if (vanillaJEITypeEMICategoryMap.containsKey(jeiRecipeType) && recipe.getOriginalID() != null) {
 				if (emiRecipe instanceof TMRVRecipe<?>)
 					LOGGER.warn("Recipe replacement for {} will not render properly!", recipe.getOriginalID());
 				
@@ -784,16 +785,6 @@ public class RecipeManager implements IRecipeManager, TooManyRecipeViewers.ILock
 			}
 			
 			return Objects.requireNonNull(emiCategory);
-		}
-		
-		private @Nullable Boolean isVanillaType;
-		
-		public synchronized boolean isVanillaType() {
-			if (isVanillaType == null) {
-				final var recipeType = getJEIRecipeType();
-				isVanillaType = recipeType != null && vanillaJEITypeEMICategoryMap.containsKey(recipeType);
-			}
-			return isVanillaType;
 		}
 		
 		//region Recipe

--- a/src/main/java/dev/nolij/toomanyrecipeviewers/impl/jei/api/recipe/RecipeManager.java
+++ b/src/main/java/dev/nolij/toomanyrecipeviewers/impl/jei/api/recipe/RecipeManager.java
@@ -456,17 +456,18 @@ public class RecipeManager implements IRecipeManager, TooManyRecipeViewers.ILock
 	private final Set<ResourceLocation> replacedRecipeIDs = Collections.synchronizedSet(new HashSet<>());
 	private final Set<EmiRecipe> replacementRecipes = Collections.synchronizedSet(new HashSet<>());
 	private <T> void addRecipe(Category<T> category, T jeiRecipe) {
+		final var jeiCategory = category.getJEICategory();
+		final var jeiRecipeType = Objects.requireNonNull(jeiCategory).getRecipeType();
 		//? if >=21.1 {
-		if (jeiRecipe instanceof RecipeHolder<?> holder && 
+		if (vanillaJEITypeEMICategoryMap.containsKey(jeiRecipeType) &&
+			jeiRecipe instanceof RecipeHolder<?> holder && 
 			runtime.ignoredRecipes.contains(holder.value()))
 			return;
 		//?} else {
-		/*if (runtime.ignoredRecipes.contains(jeiRecipe))
+		/*if (vanillaJEITypeEMICategoryMap.containsKey(jeiRecipeType) &&
+			runtime.ignoredRecipes.contains(jeiRecipe))
 			return;
 		*///?}
-		
-		final var jeiCategory = category.getJEICategory();
-		final var jeiRecipeType = Objects.requireNonNull(jeiCategory).getRecipeType();
 		if (!jeiCategory.isHandled(jeiRecipe)) {
 			if (LOGGER.isDebugEnabled()) {
 				String recipeInfo = RecipeDebugUtil.getDebugInfoFromRecipe(jeiRecipe, jeiCategory, ingredientManager);

--- a/src/main/java/dev/nolij/toomanyrecipeviewers/impl/jei/api/recipe/RecipeManager.java
+++ b/src/main/java/dev/nolij/toomanyrecipeviewers/impl/jei/api/recipe/RecipeManager.java
@@ -456,19 +456,18 @@ public class RecipeManager implements IRecipeManager, TooManyRecipeViewers.ILock
 	private final Set<ResourceLocation> replacedRecipeIDs = Collections.synchronizedSet(new HashSet<>());
 	private final Set<EmiRecipe> replacementRecipes = Collections.synchronizedSet(new HashSet<>());
 	private <T> void addRecipe(Category<T> category, T jeiRecipe) {
-		final var jeiCategory = category.getJEICategory();
-		final var jeiRecipeType = Objects.requireNonNull(jeiCategory).getRecipeType();
 		//? if >=21.1 {
-		if (vanillaJEITypeEMICategoryMap.containsKey(jeiRecipeType) &&
+		if (category.isVanillaType() &&
 			jeiRecipe instanceof RecipeHolder<?> holder && 
 			runtime.ignoredRecipes.contains(holder.value()))
 			return;
 		//?} else {
-		/*if (vanillaJEITypeEMICategoryMap.containsKey(jeiRecipeType) &&
+		/*if (category.isVanillaType() &&
 			runtime.ignoredRecipes.contains(jeiRecipe))
 			return;
 		*///?}
-		if (!jeiCategory.isHandled(jeiRecipe)) {
+		final var jeiCategory = category.getJEICategory();
+		if (!Objects.requireNonNull(jeiCategory).isHandled(jeiRecipe)) {
 			if (LOGGER.isDebugEnabled()) {
 				String recipeInfo = RecipeDebugUtil.getDebugInfoFromRecipe(jeiRecipe, jeiCategory, ingredientManager);
 				LOGGER.debug("Recipe not added because the recipe category cannot handle it: {}", recipeInfo);
@@ -480,7 +479,7 @@ public class RecipeManager implements IRecipeManager, TooManyRecipeViewers.ILock
 			final var recipe = category.recipe(jeiRecipe);
 			final var emiRecipe = Objects.requireNonNull(recipe.getEMIRecipe());
 			registry.addRecipe(emiRecipe);
-			if (vanillaJEITypeEMICategoryMap.containsKey(jeiRecipeType) && recipe.getOriginalID() != null) {
+			if (category.isVanillaType() && recipe.getOriginalID() != null) {
 				if (emiRecipe instanceof TMRVRecipe<?>)
 					LOGGER.warn("Recipe replacement for {} will not render properly!", recipe.getOriginalID());
 				
@@ -785,6 +784,16 @@ public class RecipeManager implements IRecipeManager, TooManyRecipeViewers.ILock
 			}
 			
 			return Objects.requireNonNull(emiCategory);
+		}
+		
+		private @Nullable Boolean isVanillaType;
+		
+		public synchronized boolean isVanillaType() {
+			if (isVanillaType == null) {
+				final var recipeType = getJEIRecipeType();
+				isVanillaType = recipeType != null && vanillaJEITypeEMICategoryMap.containsKey(recipeType);
+			}
+			return isVanillaType;
 		}
 		
 		//region Recipe


### PR DESCRIPTION
Fixes #24, Fixes #47

Create's fan smoking and blasting category using vanilla `RecipeType` as recipe type. But they are added to `runtime.ignoredRecipes` through `VanillaPluginMixin`, so when adding fan smoking/blasting recipes, they are ignored. Resulting blasting and smoking not shown in EMI Categories.

This PR adds one more check before ignoring. If the category is not in `vanillaJEITypeEMICategoryMap`, the recipe will still be added.

Tested by add create to runtime only mods and `./gradlew :20.1-lexforge:runClient`:

<img width="439" height="315" alt="image" src="https://github.com/user-attachments/assets/ff72fb34-fa33-4db9-8c25-5f4b1e6281a4" />
