### PR TITLE
fix: skip recipes with skipped recipe types

### DIFF
--- a/src/main/java/dev/nolij/toomanyrecipeviewers/EMIPlugin.java
+++ b/src/main/java/dev/nolij/toomanyrecipeviewers/EMIPlugin.java
@@ -65,6 +65,8 @@ import org.jetbrains.annotations.NotNull;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
@@ -251,12 +253,14 @@ public final class EMIPlugin implements EmiPlugin {
 		final var emiCategoryIDs = EmiRecipes.categories.stream().map(EmiRecipeCategory::getId).collect(Collectors.toSet());
 		
 		final var recipeCategories = new ArrayList<IRecipeCategory<?>>();
+		final var skippedRecipeTypes = new HashSet<mezz.jei.api.recipe.RecipeType<?>>();
 		for (final var category : recipeCategoryRegistration.getRecipeCategories()) {
 			final var recipeType = category.getRecipeType();
 			final var uid = recipeType.getUid();
 			if (!RecipeManager.vanillaJEITypeEMICategoryMap.containsKey(recipeType) && 
 				emiCategoryIDs.contains(uid)) {
 				LOGGER.warn("Skipping JEI category with ID `{}` which already exists in EMI!", uid.toString());
+				skippedRecipeTypes.add(recipeType);
 				continue;
 			}
 			
@@ -264,6 +268,7 @@ public final class EMIPlugin implements EmiPlugin {
 		}
 		
 		runtime.recipeCategories = recipeCategories;
+		runtime.skippedRecipeTypes = Collections.unmodifiableSet(skippedRecipeTypes);
 	}
 	
 	private void registerRecipeCatalysts() {

--- a/src/main/java/dev/nolij/toomanyrecipeviewers/TooManyRecipeViewers.java
+++ b/src/main/java/dev/nolij/toomanyrecipeviewers/TooManyRecipeViewers.java
@@ -84,6 +84,7 @@ public final class TooManyRecipeViewers {
 	public volatile @Unmodifiable List<IRecipeCategory<?>> recipeCategories = null;
 	public volatile ImmutableListMultimap<RecipeType<?>, ITypedIngredient<?>> recipeCatalysts = null;
 	public final Set<Object> ignoredRecipes = new HashSet<>();
+	public volatile Set<mezz.jei.api.recipe.RecipeType<?>> skippedRecipeTypes = Set.of();
 	public volatile RecipeManager recipeManager = null;
 	public volatile IRecipeTransferManager recipeTransferManager = null;
 	public volatile IScreenHelper screenHelper = null;

--- a/src/main/java/dev/nolij/toomanyrecipeviewers/impl/jei/api/recipe/RecipeManager.java
+++ b/src/main/java/dev/nolij/toomanyrecipeviewers/impl/jei/api/recipe/RecipeManager.java
@@ -269,6 +269,12 @@ public class RecipeManager implements IRecipeManager, TooManyRecipeViewers.ILock
 		if (locked)
 			throw new IllegalStateException("Tried to add recipes after registry is locked");
 		
+		if (runtime.skippedRecipeTypes.contains(jeiRecipeType)) {
+			LOGGER.debug("Skipping {} recipes for RecipeType {} (category handled natively by EMI)",
+				jeiRecipes.size(), jeiRecipeType.getUid());
+			return;
+		}
+		
 		final var category = category(jeiRecipeType);
 		
 		for (final var jeiRecipe : jeiRecipes) {
@@ -281,6 +287,9 @@ public class RecipeManager implements IRecipeManager, TooManyRecipeViewers.ILock
 	private <T> void collectRecipes(RecipeType<T> recipeType, Collection<T> jeiRecipes, Consumer<ResourceLocation> idConsumer) {
 		if (locked)
 			throw new IllegalStateException();
+		
+		if (runtime.skippedRecipeTypes.contains(recipeType))
+			return;
 		
 		final var category = category(recipeType);
 		final var recipes = jeiRecipes.stream().map(category::recipe).toList();
@@ -307,6 +316,9 @@ public class RecipeManager implements IRecipeManager, TooManyRecipeViewers.ILock
 		if (locked)
 			throw new IllegalStateException();
 		
+		if (runtime.skippedRecipeTypes.contains(recipeType))
+			return;
+		
 		hiddenCategories.add(category(recipeType).getEMICategory());
 	}
 	
@@ -314,6 +326,9 @@ public class RecipeManager implements IRecipeManager, TooManyRecipeViewers.ILock
 	public void unhideRecipeCategory(RecipeType<?> recipeType) {
 		if (locked)
 			throw new IllegalStateException();
+		
+		if (runtime.skippedRecipeTypes.contains(recipeType))
+			return;
 		
 		hiddenCategories.remove(category(recipeType).getEMICategory());
 	}


### PR DESCRIPTION
When a mod registered JEI recipes with a recipe type that had been skipped (because it already existed in EMI), the recipe didn't have any category, which led to TMRV throwing an IllegalStateException.

Reproducible with Farmer's Delight 1.2.11 + TMRV 0.7.2 on MC 1.21.1: Farmer's Delight's JEI plugin calls `addRecipes` for its cooking/cutting/decomposition recipe types, which were already skipped in `registerRecipeCategories`.

This PR fixes this issue by skipping any JEI recipe with a skipped JEI recipe type. This mainly affects `addRecipes`, but as `hideRecipes`, `unhideRecipes`, `hideRecipeCategory` and `unhideRecipeCategory` could be called from the outside, it's in there as a precaution as well