### PR TITLE
Fix recipe flame and arrow animation speed and flame direction

### DIFF
--- a/src/main/java/dev/nolij/toomanyrecipeviewers/impl/recipe/TMRVRecipeWidget.java
+++ b/src/main/java/dev/nolij/toomanyrecipeviewers/impl/recipe/TMRVRecipeWidget.java
@@ -250,12 +250,12 @@ abstract class TMRVRecipeWidget extends Widget implements IRecipeExtrasBuilder {
 	
 	@Override
 	public IPlaceable<?> addAnimatedRecipeArrow(int cookTime) {
-		return new DeferredPlaceableWidget((x, y) -> widgets.addFillingArrow(x, y, cookTime), EmiTexture.EMPTY_ARROW.width, EmiTexture.EMPTY_ARROW.height);
+		return new DeferredPlaceableWidget((x, y) -> widgets.addFillingArrow(x, y, cookTime * 50), EmiTexture.EMPTY_ARROW.width, EmiTexture.EMPTY_ARROW.height);
 	}
 	
 	@Override
 	public IPlaceable<?> addAnimatedRecipeFlame(int cookTime) {
-		return new DeferredPlaceableWidget((x, y) -> widgets.add(new FillingFlameWidget(x, y, cookTime)), EmiTexture.EMPTY_FLAME.width, EmiTexture.EMPTY_FLAME.height);
+		return new DeferredPlaceableWidget((x, y) -> widgets.add(new FillingFlameWidget(x, y, cookTime * 50)), EmiTexture.EMPTY_FLAME.width, EmiTexture.EMPTY_FLAME.height);
 	}
 	
 	@Override

--- a/src/main/java/dev/nolij/toomanyrecipeviewers/impl/widget/FillingFlameWidget.java
+++ b/src/main/java/dev/nolij/toomanyrecipeviewers/impl/widget/FillingFlameWidget.java
@@ -8,13 +8,13 @@ import net.minecraft.client.gui.GuiGraphics;
 public class FillingFlameWidget extends AnimatedTextureWidget {
 	
 	public FillingFlameWidget(int x, int y, int time) {
-		super(EmiRenderHelper.WIDGETS, x, y, 14, 14, 68, 14, time, true, false, false);
+		super(EmiRenderHelper.WIDGETS, x, y, 14, 14, 68, 0, time, false, false, false);
 	}
 	
 	@Override
 	public void render(GuiGraphics draw, int mouseX, int mouseY, float delta) {
 		EmiDrawContext context = EmiDrawContext.wrap(draw);
-		context.drawTexture(this.texture, x, y, width, height, u, 0, regionWidth, regionHeight, textureWidth, textureHeight);
+		context.drawTexture(this.texture, x, y, width, height, u, 14, regionWidth, regionHeight, textureWidth, textureHeight);
 		super.render(context.raw(), mouseX, mouseY, delta);
 	}
 	

--- a/src/main/java/dev/nolij/toomanyrecipeviewers/impl/widget/FillingFlameWidget.java
+++ b/src/main/java/dev/nolij/toomanyrecipeviewers/impl/widget/FillingFlameWidget.java
@@ -8,7 +8,7 @@ import net.minecraft.client.gui.GuiGraphics;
 public class FillingFlameWidget extends AnimatedTextureWidget {
 	
 	public FillingFlameWidget(int x, int y, int time) {
-		super(EmiRenderHelper.WIDGETS, x, y, 14, 14, 68, 0, time, false, false, false);
+		super(EmiRenderHelper.WIDGETS, x, y, 14, 14, 68, 0, time, false, true, true);
 	}
 	
 	@Override

--- a/src/main/java/dev/nolij/toomanyrecipeviewers/impl/widget/FillingFlameWidget.java
+++ b/src/main/java/dev/nolij/toomanyrecipeviewers/impl/widget/FillingFlameWidget.java
@@ -1,6 +1,6 @@
 package dev.nolij.toomanyrecipeviewers.impl.widget;
 
-import dev.emi.emi.EmiRenderHelper;
+import dev.emi.emi.api.render.EmiTexture;
 import dev.emi.emi.api.widget.AnimatedTextureWidget;
 import dev.emi.emi.runtime.EmiDrawContext;
 import net.minecraft.client.gui.GuiGraphics;
@@ -8,14 +8,24 @@ import net.minecraft.client.gui.GuiGraphics;
 public class FillingFlameWidget extends AnimatedTextureWidget {
 	
 	public FillingFlameWidget(int x, int y, int time) {
-		super(EmiRenderHelper.WIDGETS, x, y, 14, 14, 68, 0, time, false, true, true);
+		super(EmiTexture.FULL_FLAME.texture, x, y,
+				EmiTexture.FULL_FLAME.width, EmiTexture.FULL_FLAME.height,
+				EmiTexture.FULL_FLAME.u, EmiTexture.FULL_FLAME.v,
+				EmiTexture.FULL_FLAME.regionWidth, EmiTexture.FULL_FLAME.regionHeight,
+				EmiTexture.FULL_FLAME.textureWidth, EmiTexture.FULL_FLAME.textureHeight,
+				time, false, true, true);
 	}
 	
 	@Override
 	public void render(GuiGraphics draw, int mouseX, int mouseY, float delta) {
 		EmiDrawContext context = EmiDrawContext.wrap(draw);
-		context.drawTexture(this.texture, x, y, width, height, u, 14, regionWidth, regionHeight, textureWidth, textureHeight);
+
+		context.drawTexture(EmiTexture.EMPTY_FLAME.texture, x, y,
+				EmiTexture.EMPTY_FLAME.width, EmiTexture.EMPTY_FLAME.height,
+				EmiTexture.EMPTY_FLAME.u, EmiTexture.EMPTY_FLAME.v,
+				EmiTexture.EMPTY_FLAME.regionWidth, EmiTexture.EMPTY_FLAME.regionHeight,
+				EmiTexture.EMPTY_FLAME.textureWidth, EmiTexture.EMPTY_FLAME.textureHeight);
+
 		super.render(context.raw(), mouseX, mouseY, delta);
 	}
-	
 }


### PR DESCRIPTION
Fixes an issue where recipe progress arrows and fuel flames were animating extremely fast

Changes:
- Multiplied JEI's tick-based `cookTime` by 50 in `TMRVRecipeWidget` to properly provide milliseconds as EMI's animated widgets expect
- Updated `FillingFlameWidget` to natively use `EmiTexture.FULL_FLAME` and EmiTexture.EMPTY_FLAME. The widget now draws the empty flame in the background and uses EMI's standard fuel parameters (horizontal=false, endToStart=true, fullToEmpty=true)

Tested and confirmed to be working with Clayworks baking recipes

Closes #58 